### PR TITLE
add python-dev to test containers

### DIFF
--- a/test/docker/Dockerfile.amazon-linux2
+++ b/test/docker/Dockerfile.amazon-linux2
@@ -1,6 +1,8 @@
 FROM amazonlinux
 
 RUN yum install -y \
+        "@Development tools" \
+        python3-devel \
         python3-pip \
         libgomp \
         mesa-libGL

--- a/test/docker/Dockerfile.focal
+++ b/test/docker/Dockerfile.focal
@@ -2,6 +2,7 @@ FROM ubuntu:focal
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+    python3-dev \
     python3-pip \
     libgl1 \
     libglib2.0-0


### PR DESCRIPTION
Add the dev packages for testing. I plan to also update the getting started guide to recommend this as well. This fixes several of the packages which currently fail on AL2 but pass on Focal.