### PR TITLE
Include test stderr output in results file.

### DIFF
--- a/test/test-packages.py
+++ b/test/test-packages.py
@@ -148,7 +148,7 @@ def do_test(package_main_name, package_list, container, test_sh_script, test_py_
             encoding='utf-8', stdout=subprocess.PIPE)
     return_code = int(proc.stdout.strip())
     proc = subprocess.run(['docker', 'logs', container_id],
-            encoding='utf-8', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            encoding='utf-8', stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     output = proc.stdout
 
     if time.time() - start > SLOW_INSTALL_TIME:


### PR DESCRIPTION
We've currently got 20 failures, but the cause is not available in the results JSON because stderr was being thrown away. With this change, stderr will be included in each test's output.

An example that currently has empty output, but now shows the error
```
"focal": {
  "test-passed": false,
  "build-required": false,
  "binary-wheel": false,
  "slow-install": false,
  "timeout": false,
  "output": "ERROR: Could not find a version that satisfies the requirement tensorflow (from versions: none)\nERROR: No matching distribution found for tensorflow\n"
}
```

I am separately working on incorporating these outputs into the HTML report to make the errors even easier to see.