### PR TITLE
Update the wheel-tester with the following enhancements:

### DIFF
--- a/test/container-script.sh
+++ b/test/container-script.sh
@@ -3,5 +3,12 @@
 set -e
 
 cd /io
-pip3 install $PIP_EXTRA_ARGS $PACKAGE_LIST
+python3 -m venv .test
+source .test/bin/activate
+pip3 install --progress-bar off --upgrade pip
+
+# Check if we will have a mismatch between latest release and wheel, by doing a dry-run
+pip3 install --dry-run --progress-bar off --report pip_latest.json $PIP_EXTRA_ARGS $PACKAGE_LIST &> dryrun_output.log
+
+pip3 install --prefer-binary --progress-bar off --report pip_binary.json $PIP_EXTRA_ARGS $PACKAGE_LIST
 python3 test-script.py

--- a/test/docker/Dockerfile.amazon-linux2
+++ b/test/docker/Dockerfile.amazon-linux2
@@ -8,4 +8,4 @@ RUN yum install -y \
         mesa-libGL
 ADD https://repo.anaconda.com/archive/Anaconda3-2021.04-Linux-aarch64.sh /root/anaconda.sh
 RUN bash ~/anaconda.sh -b -p $HOME/anaconda
-RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install virtualenv

--- a/test/docker/Dockerfile.amazon-linux2-py38
+++ b/test/docker/Dockerfile.amazon-linux2-py38
@@ -8,4 +8,4 @@ RUN yum install -y \
         python38-pip \
         libgomp \
         mesa-libGL
-RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install virtualenv

--- a/test/docker/Dockerfile.amazon-linux2023
+++ b/test/docker/Dockerfile.amazon-linux2023
@@ -4,5 +4,6 @@ RUN yum install -y \
         "@Development tools" \
         python3-devel \
         python3-pip \
+        python3-virtualenv \
         libgomp \
         mesa-libGL

--- a/test/docker/Dockerfile.focal
+++ b/test/docker/Dockerfile.focal
@@ -4,8 +4,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     python3-dev \
     python3-pip \
+    python3-venv \
     libgl1 \
     libglib2.0-0
-RUN python3 -m pip install --upgrade pip
 ADD https://repo.anaconda.com/archive/Anaconda3-2021.04-Linux-aarch64.sh /root/anaconda.sh
 RUN bash ~/anaconda.sh -b -p $HOME/anaconda

--- a/test/docker/Dockerfile.noble
+++ b/test/docker/Dockerfile.noble
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \

--- a/test/process-results.py
+++ b/test/process-results.py
@@ -178,7 +178,7 @@ def get_package_name_class(test_name):
         return 'package-pip'
 
 def get_distribution_name(test_name):
-    distros = ["amazon-linux2", "centos8", "focal", "jammy"]
+    distros = ["amazon-linux2", "centos8", "focal", "jammy", "noble"]
     for distro in distros:
         if distro in test_name:
             return distro
@@ -383,6 +383,10 @@ def print_table_by_distro_report(test_results_fname_list, ignore_tests=[], compa
                 else:
                     html.append(make_badge(classes=['failed'], text='failed'))
                     show_output = True
+                if result["installed-version"]:
+                    html.append(make_badge(classes=['passed'], text=f"installed version {result['installed-version']}"))
+                if result["installed-version"] and (result["installed-version"] != result["latest-version"]):
+                    html.append(make_badge(classes=['warning'], text=f"latest version {result['latest-version']}"))
                 if result['build-required']:
                     html.append(make_badge(classes=['warning'], text='build required'))
                 if result['slow-install']:

--- a/test/setup-containers.sh
+++ b/test/setup-containers.sh
@@ -7,11 +7,11 @@ cd "$( dirname "${BASH_SOURCE[0]}" )"
 
 # fetch the latest version of each base image
 # without this step the build phase will use cached (old) versions of the base containers
-for image in 'ubuntu:focal' 'ubuntu:jammy' 'amazonlinux:2' 'amazonlinux:2023'; do
+for image in 'ubuntu:focal' 'ubuntu:jammy' 'ubuntu:noble' 'amazonlinux:2' 'amazonlinux:2023'; do
     docker pull ${image}
 done
 
-for image in 'focal' 'jammy' 'amazon-linux2' 'amazon-linux2-py38' 'amazon-linux2023'; do
+for image in 'focal' 'jammy' 'noble' 'amazon-linux2' 'amazon-linux2-py38' 'amazon-linux2023'; do
     docker build -t wheel-tester/${image} -f docker/Dockerfile.${image} .
 done
 


### PR DESCRIPTION
- Add Ubuntu 24.04 (Noble) to test matrix
- Convert to using virtualenvs to install latest version of pip to containers to account for latest distros (AL2023, Ubuntu 24.04) not allowing system-wide pip installs
- Use --prefer-binary on pip install to let the pkg manager search for the latest known binary wheel for a package if the latest is only a source release.  Add a badge to the report stating what version for the tested distro and python interpretter was installed.
- Run a second --dry-run pip install to detect if the installed wheel version is different from the latest release.  Add a badge if the installed version and the latest package release version that supports the current interpretter differ.