### PR TITLE
Raise wheel install timeout and upgrade self-hosted runner

### DIFF
--- a/.github/workflows/wheel-test.yaml
+++ b/.github/workflows/wheel-test.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   ubuntu_wheel_test:
-    runs-on: [self-hosted, linux, ARM64, m6g]
+    runs-on: [self-hosted, linux, ARM64]
     name: "Test Python Wheels"
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A report of the test status is generated daily and posted [here](https://geoffre
 
 This project could also be repurposed for other interpreted languages that contain native bindings, such as Ruby Gems.
 
-# Using the CDK to generate self-hosted Graviton2 runners for testing Wheels!
+# Using the CDK to generate self-hosted Graviton runners for testing Wheels!
 
 This projects uses the AWS CDK to stand up some infra-structure in AWS for testing
-python wheels built for Arm64 on Graviton2 processors.  The CDK scripts will allow one to
-stand up an m6g.large runner and attempts to install with the necessary dependencies for github runners.
+python wheels built for Arm64 on Graviton processors.  The CDK scripts will allow one to
+stand up an m8g.2xlarge runner and attempts to install with the necessary dependencies for github runners.
 If the installation fails, just follow the steps from github to manually install the runners.
 
 To use:

--- a/arm64_wheel_tester_stack/arm64_wheel_tester_stack.py
+++ b/arm64_wheel_tester_stack/arm64_wheel_tester_stack.py
@@ -104,7 +104,7 @@ class Arm64WheelTesterStack(core.Stack):
                                      "apt-get install -y docker-ce docker-ce-cli containerd.io",
                                      "systemctl start docker")
         instance_focal1 = ec2.Instance(self, "focal1-tester",
-            instance_type=ec2.InstanceType("m6g.large"),
+            instance_type=ec2.InstanceType("m8g.2xlarge"),
             machine_image=ubuntu,
             vpc=vpc,
             key_name=KEY_NAME,

--- a/test/test-packages.py
+++ b/test/test-packages.py
@@ -17,7 +17,7 @@ process_results = importlib.import_module("process-results")
 generate_website = importlib.import_module("generate-website")
 
 SLOW_INSTALL_TIME = 60
-TIMEOUT = 180
+TIMEOUT = 600
 
 
 def main():


### PR DESCRIPTION
Two small changes to make the tester more resilient to large wheel installs:

1. **Raise `TIMEOUT` from 180s to 600s** in `test/test-packages.py`. 180s was
   a heuristic to catch wheels that fall back to building from source, but it
   also flags legitimate binary-wheel installs with large dependency trees.
   A recent example: pytorch 2.11.0 on aarch64. Upstream removed the
   `platform_machine == "x86_64"` gate on their CUDA runtime deps, so aarch64
   now pulls cuda-toolkit, cudnn-cu13, cusparselt-cu13, nccl-cu13, nvshmem-cu13,
   triton, etc. — roughly 2.8 GB of wheels — before install even starts. On
   the current runner the test is killed by the 180s timeout partway through
   the download phase.

2. **Upgrade the self-hosted runner from `m6g.large` to `m8g.2xlarge`** (CDK
   stack + README). More vCPUs, memory, and network bandwidth help with both
   the download and the unpack phases of large wheels. The workflow's `m6g`
   runner label is also removed so it no longer pins to a specific Graviton
   generation; `[self-hosted, linux, ARM64]` is enough to uniquely select
   the tester's runner.

### Verification

Reproduced the current failure and validated the proposed fix on a
freshly-launched `m8g.2xlarge` EC2 instance (us-west-2, same Ubuntu focal
arm64 AMI the CDK resolves), running the exact `test/test-packages.py`
invocation that `.github/workflows/wheel-test.yaml` runs.

**Run A — m8g.2xlarge with existing `TIMEOUT = 180`:**

| Wheel       | Container | Result    | Runtime | Timeout hit |
|-------------|-----------|-----------|---------|-------------|
| torch       | jammy     | FAILED    | 180.3s  | yes         |
| torch       | noble     | FAILED    | 180.2s  | yes         |
| torchvision | jammy     | FAILED    | 180.4s  | yes         |
| torchvision | noble     | FAILED    | 180.3s  | yes         |

All four hit the 180s ceiling. The runner bump alone is not enough.

**Run B — m8g.2xlarge with `TIMEOUT = 600` (this PR):**

| Wheel       | Container | Result    | Runtime | Timeout hit |
|-------------|-----------|-----------|---------|-------------|
| torch       | jammy     | PASSED    | 307.0s  | no          |
| torch       | noble     | PASSED    | 329.2s  | no          |
| torchvision | jammy     | PASSED    | 346.4s  | no          |
| torchvision | noble     | PASSED    | 343.4s  | no          |

All four pass. Slowest install is 346s, so 600s leaves comfortable headroom.
All four still get the `slow-install` (yellow) badge since runtime > 60s, so
the regression remains visible on the dashboard — it just isn't fatal.

Run A confirms the runner bump alone is insufficient. Run B confirms that
both changes together fix the failure.

### Out of scope for this PR

- The `torchaudio` failure currently visible on the dashboard has a different root cause:
  the test scaffolding creates an isolated venv per package, so
  `import torchaudio` fails with `ModuleNotFoundError: No module named
  'torch'` regardless of runner size or timeout. Pre-existing tester issue,
  affects any wheel that imports another wheel from our package list on
  import. Worth a follow-up.
- `torchvision` on `al2` is stuck at 0.14.1 because AL2's glibc is too old
  for manylinux_2_28 wheels. Also pre-existing and out of scope here.

### Deployment note

Applying the CDK change replaces the EC2 instance, so the self-hosted runner
agent needs to be re-registered on the new host (the existing user_data
installs Docker but not the runner agent, per the README: "If the
installation fails, just follow the steps from github to manually install
the runners").